### PR TITLE
Spell parameters correctly in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@ public class CustomConvention : Convention
 <div class="one-third column">
 <p><strong>Tell Fixie where test method parameters come from.</strong>
 <p>By default, Fixie has no idea where test method parameters come from.</p>
-<p>Your custom conventions can specify how to resolve test method paramters.</p>
+<p>Your custom conventions can specify how to resolve test method parameters.</p>
 </div>
 <div class="two-thirds column">
 {% highlight csharp %}


### PR DESCRIPTION
There may be more errors but his one jumped out at me...